### PR TITLE
bump ws to ^8.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "socket.io-client",
     "description": "Socket.IO client for the browser and node.js",
-    "version": "0.9.17-overleaf-5",
+    "version": "0.9.17-overleaf-6",
     "main": "./lib/io.js",
     "browserify": "./dist/socket.io.js",
     "homepage": "http://socket.io",
@@ -37,7 +37,7 @@
         "url": "https://github.com/LearnBoost/socket.io-client.git"
     },
     "dependencies": {
-        "ws": "^1.1.5",
+        "ws": "^8.21.0",
         "xmlhttprequest": "^1.8.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Bumps `ws` from `^1.1.5` to `^8.21.0` to fix [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) (memory exhaustion DoS via tiny fragments and data chunks).

The client-side WebSocket API (`new WebSocket(url)` + EventEmitter events) is compatible across ws@1–8. Verified: overleaf/internal acceptance tests for `services/real-time` pass with ws@8.21.0 forced via a yarn resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)